### PR TITLE
fix(macOS/tray): update deprecated functions

### DIFF
--- a/src/tray.rs
+++ b/src/tray.rs
@@ -126,11 +126,10 @@ pub fn launch() {
                 // We have to request a redraw here to have the icon actually show up.
                 // Tao only exposes a redraw method on the Window so we use core-foundation directly.
                 #[cfg(target_os = "macos")]
-                unsafe {
-                    use objc2_core_foundation::{CFRunLoopGetMain, CFRunLoopWakeUp};
-
-                    let rl = CFRunLoopGetMain().unwrap();
-                    CFRunLoopWakeUp(&rl);
+                {
+                    use objc2_core_foundation::CFRunLoop;
+                    let rl = CFRunLoop::main().unwrap();
+                    rl.wake_up();
                 }
             }
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
CFRunLoopGetMain and CFRunLoopWakeUp are deprecated. The unsafe code was also not necessary.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
