### PR TITLE
fix: cross-platform dev:mock + logs view Message column collapsing on narrow viewports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ crates/client-web/dist/
 
 # dev temp files
 .dev/
+
+# git worktrees
+.worktrees/

--- a/crates/client-web/.env.mock
+++ b/crates/client-web/.env.mock
@@ -1,0 +1,4 @@
+# Activated automatically by `npm run dev:mock`, which runs `vite --mode mock`.
+# Vite loads `.env.[mode]` files, so this file turns on the in-browser mock API
+# without needing any OS-specific env-var syntax in package.json scripts.
+VITE_USE_MOCK_API=true

--- a/crates/client-web/package.json
+++ b/crates/client-web/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:mock": "set VITE_USE_MOCK_API=true&& vite",
+    "dev:mock": "vite --mode mock",
+    "dev:mock:win": "set VITE_USE_MOCK_API=true&& vite",
     "build": "vite build",
     "preview": "vite preview",
     "check": "tsc --noEmit"

--- a/crates/client-web/src/app/dashboardView.ts
+++ b/crates/client-web/src/app/dashboardView.ts
@@ -269,7 +269,7 @@ export function renderLogViewer(): string {
                   <th>Level</th>
                   <th>Module</th>
                   <th>Source</th>
-                  <th>Message</th>
+                  <th class="log-message-col">Message</th>
                 </tr>
               </thead>
               <tbody>${logEntries.map((entry) => {
@@ -285,7 +285,7 @@ export function renderLogViewer(): string {
                   <td><span class="tag ${levelTagClass}">${escapeHtml(entry.level)}</span></td>
                   <td>${escapeHtml(entry.module)}</td>
                   <td class="muted">${escapeHtml(entry.source_file_path)}${typeof entry.line_number === 'number' ? `:${entry.line_number}` : ''}</td>
-                  <td><pre class="log-entry-message">${escapeHtml(entry.message)}</pre></td>
+                  <td class="log-message-col"><pre class="log-entry-message">${escapeHtml(entry.message)}</pre></td>
                 </tr>
               `;
               }).join('')}</tbody>

--- a/crates/client-web/src/style.css
+++ b/crates/client-web/src/style.css
@@ -2123,6 +2123,15 @@ legend {
   font-size: 0.84rem;
 }
 
+/* The Message column keeps a fixed minimum width in characters regardless of
+   available viewport space. Since the table sits inside a horizontally
+   scrollable .table-shell, this never clips it; it just guarantees the column
+   is always wide enough to read instead of getting crushed by auto-layout. */
+.log-entries-table .log-message-col {
+  min-width: 70ch;
+  width: 70ch;
+}
+
 .log-filter-row {
   align-items: end;
 }


### PR DESCRIPTION

<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    THEY ARE OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

Two small, self-contained client-web fixes:

1. **Logs table: Message column no longer crushes to ~7 chars wide.** On small windows the auto-layout table squeezed the wrapped `<pre>` in the Message column down to a few characters, making the log viewer effectively unreadable on narrow viewports. Since the table is already horizontally scrollable, the column now keeps a guaranteed ~70-character minimum width.
2. **`npm run dev:mock` now works on macOS/Linux.** The script used cmd.exe-only `set VITE_USE_MOCK_API=true&&` syntax and failed on Unix shells. It now uses Vite's first-class `--mode mock` flag (auto-loads a new `.env.mock`), which is OS-agnostic and requires no new dependencies.

### Details

**Logs Message column** (`crates/client-web/src/app/dashboardView.ts` + `crates/client-web/src/style.css`):
- Tagged the `Message` `<th>` and its `<td>` cells with `class="log-message-col"`.
- Added a CSS rule pinning the column to a character-based minimum:

  ```css
  .log-entries-table .log-message-col {
    min-width: 70ch;
    width: 70ch;
  }
  ```

- `ch` units track the `0` glyph width, so the column reliably holds ~70 characters regardless of viewport size. Because the table lives inside a horizontally scrollable `.table-shell`, this **never clips** content — it only stops the column from being crushed.

**Cross-platform `dev:mock`** (`crates/client-web/package.json` + new `crates/client-web/.env.mock`):
- `dev:mock` now runs `vite --mode mock`, which makes Vite auto-load the new `.env.mock` file (`VITE_USE_MOCK_API=true`). The `import.meta.env` reading in `api.ts` is unchanged.
- The previous Windows-specific command is preserved as `dev:mock:win` so nobody is broken.

### Verification

- `npm run check` (tsc `--noEmit`) — ✅ passes
- `npm run build` (vite build) — ✅ passes
- `npm run dev:mock` — ✅ confirmed serving with `"VITE_USE_MOCK_API": "true"` inlined into `import.meta.env`, mock mode active, served at `http://127.0.0.1:4173/`

### Testing instructions (mock API)

```bash
cd crates/client-web
npm run dev:mock   # now works on macOS/Linux/Windows
```

Log in with the seeded mock admin (defined in `src/mockApi.ts`, browser-only — never touches the server):

```
username: admin
password: adminpass
```

Then navigate to **Settings → Logs** and resize the window narrow to confirm the Message column stays readable (~70 chars) and the table scrolls horizontally.

### Notes

- No backend, API, or DB changes.
- No new runtime dependencies (`lucide` remains the only one).
- Targets `feat/initial-concept`.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->

<!-- TODO: attach a screenshot of Settings → Logs at a narrow viewport width, showing the Message column staying readable while the table scrolls horizontally. -->

### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->

<!-- None. -->

#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->

<!-- None. -->

## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)

## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
